### PR TITLE
Implement example library and runtime overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +778,15 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "deranged"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive-name"
@@ -1157,6 +1175,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1649,6 +1688,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,10 +1864,17 @@ dependencies = [
  "egui",
  "env_logger",
  "koto",
+ "libloading",
  "log",
+ "notify",
  "once_cell",
+ "profiling",
  "serde",
  "serde_json",
+ "tempfile",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1877,6 +1943,32 @@ dependencies = [
  "serde",
  "thiserror 2.0.16",
 ]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -2010,6 +2102,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +2205,40 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.9.4",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -2611,6 +2749,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +2783,19 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pxfm"
@@ -2910,6 +3067,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,6 +3296,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3141,6 +3316,37 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3220,6 +3426,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3455,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3312,6 +3556,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -3968,6 +4218,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4015,6 +4274,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4067,6 +4341,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4085,6 +4365,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4100,6 +4386,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4133,6 +4425,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4148,6 +4446,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4169,6 +4473,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4184,6 +4494,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,16 @@ eframe = "0.32.3"
 egui = "0.32.3"
 env_logger = "0.11.8"
 koto = { version = "0.16.0", default-features = false, features = ["arc", "serde"] }
+libloading = "0.8.9"
 log = "0.4.28"
+notify = "6.1.1"
 once_cell = "1.21.3"
+profiling = "1.0.17"
 serde = { version = "1.0.226", features = ["derive"] }
 serde_json = "1.0.145"
+tracing = "0.1.41"
+tracing-appender = "0.2.3"
+tracing-subscriber = { version = "0.3.18", features = ["fmt", "ansi"] }
+
+[dev-dependencies]
+tempfile = "3.13.0"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,41 @@
+# Example Library Layout
+
+Koto Learning loads runnable examples from the `examples/` directory that ships
+with the binary. Each example lives inside its own folder and must provide both
+a script and metadata:
+
+```
+examples/
+  └─ hello_world/
+      ├─ script.koto
+      └─ meta.json
+```
+
+## `meta.json` schema
+
+The metadata file is parsed as JSON with the following fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | Unique identifier for the example. Defaults to the folder name when omitted. |
+| `title` | string | Human friendly title displayed in the UI. |
+| `description` | string | Short summary of what the example demonstrates. |
+| `note` | string (optional) | Additional text shown alongside the description. |
+| `doc_url` | string (optional) | Link to reference documentation for deeper reading. |
+| `run_instructions` | string (optional) | Step-by-step guidance for running or modifying the example. |
+| `categories` | array of strings | Tags used for filtering/grouping inside the explorer UI. Empty by default. |
+
+## `script.koto`
+
+The `script.koto` file contains the Koto source code that should be evaluated
+when the example is run. Files are read using UTF-8 encoding.
+
+## Hot reloading
+
+`koto_learning` watches the `examples/` tree at runtime using `notify`. Any
+edits to `meta.json` or `script.koto` files automatically trigger a reload of
+the in-memory example catalogue. Changes become visible in the UI without
+restarting the application.
+
+Set the `KOTO_EXAMPLES_DIR` environment variable to point to an alternative
+examples directory when testing or developing.

--- a/examples/fibonacci/meta.json
+++ b/examples/fibonacci/meta.json
@@ -1,0 +1,8 @@
+{
+  "id": "fibonacci",
+  "title": "Recursive Fibonacci",
+  "description": "Calculate the 10th Fibonacci number recursively.",
+  "doc_url": "https://koto.dev/docs/",
+  "run_instructions": "Try changing the input to see how execution time changes.",
+  "categories": ["math", "recursion"]
+}

--- a/examples/fibonacci/script.koto
+++ b/examples/fibonacci/script.koto
@@ -1,0 +1,3 @@
+fn fib(n) => if n <= 1 then n else fib(n - 1) + fib(n - 2)
+print("fib(10) =", fib(10))
+fib(10)

--- a/examples/hello_world/meta.json
+++ b/examples/hello_world/meta.json
@@ -1,0 +1,9 @@
+{
+  "id": "hello_world",
+  "title": "Hello World",
+  "description": "Print a traditional greeting to stdout.",
+  "note": "Demonstrates the simplest possible Koto script.",
+  "doc_url": "https://koto.dev/",
+  "run_instructions": "Press Run Example to execute the script.",
+  "categories": ["basics", "io"]
+}

--- a/examples/hello_world/script.koto
+++ b/examples/hello_world/script.koto
@@ -1,0 +1,2 @@
+print("Hello, world!")
+"Hello from Koto"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,7 +2,9 @@ use crate::{examples, runtime};
 use eframe::egui;
 
 pub struct ExplorerApp {
+    example_library: Option<&'static examples::ExampleLibrary>,
     examples: Vec<examples::Example>,
+    examples_version: usize,
     status_message: String,
 }
 
@@ -10,16 +12,21 @@ impl ExplorerApp {
     pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
         log::info!("Initializing ExplorerApp");
 
-        let examples = match examples::load_examples() {
-            Ok(examples) => examples,
+        let (example_library, examples, examples_version) = match examples::library() {
+            Ok(library) => {
+                let snapshot = library.snapshot();
+                (Some(library), snapshot, library.version())
+            }
             Err(error) => {
-                log::error!("Failed to load examples: {error}");
-                Vec::new()
+                log::error!("Failed to initialize example library: {error}");
+                (None, Vec::new(), 0)
             }
         };
 
         Self {
+            example_library,
             examples,
+            examples_version,
             status_message: String::from("Ready to explore Koto scripts"),
         }
     }
@@ -27,6 +34,14 @@ impl ExplorerApp {
 
 impl eframe::App for ExplorerApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        if let Some(library) = self.example_library {
+            let version = library.version();
+            if version != self.examples_version {
+                self.examples = library.snapshot();
+                self.examples_version = version;
+            }
+        }
+
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("Koto Learning Explorer");
             ui.label(&self.status_message);
@@ -37,11 +52,41 @@ impl eframe::App for ExplorerApp {
                 egui::ScrollArea::vertical().show(ui, |ui| {
                     for example in &self.examples {
                         ui.group(|ui| {
-                            ui.heading(&example.title);
-                            ui.label(&example.description);
+                            ui.heading(&example.metadata.title);
+                            ui.label(&example.metadata.description);
+                            if let Some(note) = &example.metadata.note {
+                                ui.label(note);
+                            }
+                            if !example.metadata.categories.is_empty() {
+                                let categories = example.metadata.categories.join(", ");
+                                ui.label(format!("Tags: {categories}"));
+                            }
+                            if let Some(doc_url) = &example.metadata.doc_url {
+                                ui.hyperlink(doc_url);
+                            }
+                            if let Some(run_instructions) = &example.metadata.run_instructions {
+                                ui.label(run_instructions);
+                            }
                             if ui.button("Run example").clicked() {
-                                match runtime::RUNTIME.evaluate_script(&example.source) {
-                                    Ok(result) => self.status_message = result,
+                                match runtime::RUNTIME.execute_script(&example.script) {
+                                    Ok(result) => {
+                                        let mut message = String::new();
+                                        if let Some(value) = result.return_value {
+                                            message.push_str(&format!("Result: {value}\n"));
+                                        }
+                                        if !result.stdout.is_empty() {
+                                            message
+                                                .push_str(&format!("Stdout:\n{}\n", result.stdout));
+                                        }
+                                        if !result.stderr.is_empty() {
+                                            message
+                                                .push_str(&format!("Stderr:\n{}", result.stderr));
+                                        }
+                                        if message.is_empty() {
+                                            message.push_str("Example executed with no output");
+                                        }
+                                        self.status_message = message;
+                                    }
                                     Err(error) => {
                                         self.status_message = format!("Error: {error}");
                                     }

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -1,29 +1,249 @@
-use std::{fs, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    sync::{Arc, RwLock},
+    time::SystemTime,
+};
 
-use anyhow::Result;
-use directories::ProjectDirs;
-use log::warn;
+use anyhow::{Context, Result};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::runtime::logging;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Example {
+pub struct ExampleMetadata {
+    #[serde(default)]
+    pub id: String,
     pub title: String,
     pub description: String,
-    pub source: String,
+    #[serde(default)]
+    pub note: Option<String>,
+    #[serde(default)]
+    pub doc_url: Option<String>,
+    #[serde(default)]
+    pub run_instructions: Option<String>,
+    #[serde(default)]
+    pub categories: Vec<String>,
 }
 
-pub fn load_examples() -> Result<Vec<Example>> {
-    let mut examples = built_in_examples();
+#[derive(Clone, Debug)]
+pub struct Example {
+    pub metadata: ExampleMetadata,
+    pub script: String,
+    pub loaded_at: SystemTime,
+}
 
-    if let Some(storage_dir) = project_data_dir() {
-        let file_path = storage_dir.join("examples.json");
-        if file_path.exists() {
-            match fs::read_to_string(&file_path) {
-                Ok(content) => match serde_json::from_str::<Vec<Example>>(&content) {
-                    Ok(mut user_examples) => examples.append(&mut user_examples),
-                    Err(error) => warn!("Failed to parse {file_path:?}: {error}"),
-                },
-                Err(error) => warn!("Failed to read {file_path:?}: {error}"),
+pub struct ExampleLibrary {
+    inner: Arc<ExampleLibraryInner>,
+    _watcher: Option<RecommendedWatcher>,
+}
+
+struct ExampleLibraryInner {
+    examples_dir: PathBuf,
+    examples: RwLock<BTreeMap<String, Example>>,
+    version: AtomicUsize,
+}
+
+static GLOBAL_LIBRARY: OnceCell<ExampleLibrary> = OnceCell::new();
+
+pub fn library() -> Result<&'static ExampleLibrary> {
+    GLOBAL_LIBRARY.get_or_try_init(|| ExampleLibrary::new(default_examples_dir()))
+}
+
+impl ExampleLibrary {
+    pub fn new(examples_dir: PathBuf) -> Result<Self> {
+        Self::with_watcher(examples_dir, true)
+    }
+
+    pub fn new_unwatched(examples_dir: PathBuf) -> Result<Self> {
+        Self::with_watcher(examples_dir, false)
+    }
+
+    pub fn refresh(&self) -> Result<()> {
+        self.inner.reload()
+    }
+
+    pub fn snapshot(&self) -> Vec<Example> {
+        self.inner.snapshot()
+    }
+
+    pub fn version(&self) -> usize {
+        self.inner.version.load(Ordering::SeqCst)
+    }
+
+    pub fn get(&self, id: &str) -> Option<Example> {
+        let guard = self.inner.examples.read().ok()?;
+        guard.get(id).cloned()
+    }
+
+    fn with_watcher(examples_dir: PathBuf, watch: bool) -> Result<Self> {
+        fs::create_dir_all(&examples_dir)
+            .with_context(|| format!("Failed to ensure examples dir {examples_dir:?}"))?;
+
+        let inner = Arc::new(ExampleLibraryInner::new(examples_dir.clone())?);
+
+        let watcher = if watch {
+            let inner = Arc::clone(&inner);
+            let mut watcher = notify::recommended_watcher(move |event| {
+                handle_watch_event(&inner, event);
+            })?;
+            watcher.watch(&examples_dir, RecursiveMode::Recursive)?;
+            Some(watcher)
+        } else {
+            None
+        };
+
+        logging::with_runtime_subscriber(|| {
+            tracing::info!(
+                target: "runtime.examples",
+                path = %examples_dir.display(),
+                count = inner.snapshot().len(),
+                "Example library initialized"
+            );
+        });
+
+        Ok(Self {
+            inner,
+            _watcher: watcher,
+        })
+    }
+}
+
+impl ExampleLibraryInner {
+    fn new(examples_dir: PathBuf) -> Result<Self> {
+        let library = Self {
+            examples_dir,
+            examples: RwLock::new(BTreeMap::new()),
+            version: AtomicUsize::new(0),
+        };
+        library.reload()?;
+        Ok(library)
+    }
+
+    fn reload(&self) -> Result<()> {
+        let examples = load_examples_from_dir(&self.examples_dir)?;
+        let count = examples.len();
+        if let Ok(mut guard) = self.examples.write() {
+            *guard = examples;
+        }
+        self.version.fetch_add(1, Ordering::SeqCst);
+        logging::with_runtime_subscriber(|| {
+            tracing::info!(
+                target: "runtime.examples",
+                path = %self.examples_dir.display(),
+                count,
+                "Reloaded examples"
+            );
+        });
+        Ok(())
+    }
+
+    fn snapshot(&self) -> Vec<Example> {
+        self.examples
+            .read()
+            .map(|examples| examples.values().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+fn handle_watch_event(inner: &Arc<ExampleLibraryInner>, event: notify::Result<Event>) {
+    match event {
+        Ok(event) if should_reload(&event.kind) => {
+            if let Err(error) = inner.reload() {
+                logging::with_runtime_subscriber(|| {
+                    tracing::error!(target: "runtime.examples", error = %error, "Failed to reload examples");
+                });
+            } else {
+                logging::with_runtime_subscriber(|| {
+                    tracing::debug!(target: "runtime.examples", ?event, "Example directory change detected");
+                });
+            }
+        }
+        Ok(_) => {}
+        Err(error) => {
+            logging::with_runtime_subscriber(|| {
+                tracing::error!(target: "runtime.examples", %error, "File watcher error");
+            });
+        }
+    }
+}
+
+fn should_reload(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) | EventKind::Any
+    )
+}
+
+fn load_examples_from_dir(dir: &Path) -> Result<BTreeMap<String, Example>> {
+    let mut examples = BTreeMap::new();
+
+    if !dir.exists() {
+        return Ok(examples);
+    }
+
+    for entry in fs::read_dir(dir).with_context(|| format!("Failed to read {dir:?}"))? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let folder_name = entry.file_name().to_string_lossy().to_string();
+        let example_dir = entry.path();
+        let meta_path = example_dir.join("meta.json");
+        let script_path = example_dir.join("script.koto");
+
+        match (
+            fs::read_to_string(&meta_path),
+            fs::read_to_string(&script_path),
+        ) {
+            (Ok(meta_content), Ok(script_content)) => {
+                match serde_json::from_str::<ExampleMetadata>(&meta_content) {
+                    Ok(mut metadata) => {
+                        if metadata.id.is_empty() {
+                            metadata.id = folder_name.clone();
+                        }
+                        let example = Example {
+                            script: script_content,
+                            metadata,
+                            loaded_at: SystemTime::now(),
+                        };
+                        examples.insert(example.metadata.id.clone(), example);
+                    }
+                    Err(error) => {
+                        logging::with_runtime_subscriber(|| {
+                            tracing::warn!(
+                                target: "runtime.examples",
+                                path = %meta_path.display(),
+                                %error,
+                                "Failed to parse example metadata"
+                            );
+                        });
+                    }
+                }
+            }
+            (Err(error), _) => {
+                logging::with_runtime_subscriber(|| {
+                    tracing::warn!(
+                        target: "runtime.examples",
+                        path = %meta_path.display(),
+                        %error,
+                        "Failed to read example metadata"
+                    );
+                });
+            }
+            (_, Err(error)) => {
+                logging::with_runtime_subscriber(|| {
+                    tracing::warn!(
+                        target: "runtime.examples",
+                        path = %script_path.display(),
+                        %error,
+                        "Failed to read example script"
+                    );
+                });
             }
         }
     }
@@ -31,23 +251,27 @@ pub fn load_examples() -> Result<Vec<Example>> {
     Ok(examples)
 }
 
-fn project_data_dir() -> Option<PathBuf> {
-    ProjectDirs::from("dev", "Koto", "KotoLearning").map(|dirs| dirs.data_dir().to_path_buf())
-}
+fn default_examples_dir() -> PathBuf {
+    if let Ok(path) = std::env::var("KOTO_EXAMPLES_DIR") {
+        return PathBuf::from(path);
+    }
 
-fn built_in_examples() -> Vec<Example> {
-    vec![
-        Example {
-            title: "Hello World".to_string(),
-            description: "Print a traditional greeting".to_string(),
-            source: "print(\"Hello, world!\")".to_string(),
-        },
-        Example {
-            title: "Fibonacci".to_string(),
-            description: "Calculate a Fibonacci number".to_string(),
-            source:
-                "\nfn fib(n) => if n <= 1 then n else fib(n - 1) + fib(n - 2)\nprint(fib(10))\n"
-                    .to_string(),
-        },
-    ]
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(Path::to_path_buf));
+
+    if let Some(dir) = exe_dir {
+        let candidate = dir.join("examples");
+        if candidate.exists() {
+            return candidate;
+        }
+        if let Some(parent) = dir.parent() {
+            let parent_candidate = parent.join("examples");
+            if parent_candidate.exists() {
+                return parent_candidate;
+            }
+        }
+    }
+
+    PathBuf::from("examples")
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,31 +1,462 @@
-use std::sync::Mutex;
+use std::{
+    collections::HashMap,
+    ffi::{CStr, c_char},
+    fs,
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant, SystemTime},
+};
 
-use anyhow::{Result, anyhow};
-use koto::Koto;
+use anyhow::{Context, anyhow};
+use koto::{Koto, KotoSettings, prelude::*, runtime::Result as KotoRuntimeResult};
+use libloading::Library;
 use once_cell::sync::Lazy;
+use serde_json::Value as JsonValue;
+use tracing::Level;
 
-pub static RUNTIME: Lazy<RuntimeState> = Lazy::new(RuntimeState::new);
+pub static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().expect("runtime init failed"));
 
-pub struct RuntimeState {
-    koto: Mutex<Koto>,
+pub struct Runtime {
+    state: Mutex<RuntimeState>,
+    stdout: BufferHandle,
+    stderr: BufferHandle,
+    profiling_enabled: Arc<AtomicBool>,
 }
 
-impl RuntimeState {
-    fn new() -> Self {
-        Self {
-            koto: Mutex::new(Koto::default()),
+#[derive(Clone, Debug)]
+pub struct ExecutionOutput {
+    pub return_value: Option<String>,
+    pub stdout: String,
+    pub stderr: String,
+    pub duration: Duration,
+}
+
+struct RuntimeState {
+    koto: Koto,
+    config: RuntimeConfig,
+    host_bindings: HashMap<String, KValue>,
+    shared_libraries: Vec<SharedLibrary>,
+    profiling_flag: Arc<AtomicBool>,
+}
+
+#[derive(Clone, Default)]
+struct RuntimeConfig {
+    execution_limit: Option<Duration>,
+    run_tests: bool,
+}
+
+struct SharedLibrary {
+    #[allow(dead_code)]
+    library: Library,
+}
+
+#[derive(Clone)]
+struct BufferHandle {
+    id: KString,
+    buffer: Arc<Mutex<String>>,
+}
+
+#[derive(Clone)]
+struct BufferFile {
+    id: KString,
+    buffer: Arc<Mutex<String>>,
+}
+
+#[repr(C)]
+struct RuntimeLibraryApi {
+    runtime: *const Runtime,
+    register_script: extern "C" fn(*const Runtime, *const c_char) -> bool,
+}
+
+impl Runtime {
+    pub fn new() -> anyhow::Result<Self> {
+        logging::init();
+
+        let stdout = BufferHandle::new("stdout");
+        let stderr = BufferHandle::new("stderr");
+        let profiling_enabled = Arc::new(AtomicBool::new(false));
+        let state = RuntimeState::new(
+            RuntimeConfig::default(),
+            &stdout,
+            &stderr,
+            &profiling_enabled,
+        )?;
+
+        Ok(Self {
+            state: Mutex::new(state),
+            stdout,
+            stderr,
+            profiling_enabled,
+        })
+    }
+
+    pub fn execute_script(&self, script: &str) -> anyhow::Result<ExecutionOutput> {
+        self.execute_script_with_timeout(script, None)
+    }
+
+    pub fn execute_script_with_timeout(
+        &self,
+        script: &str,
+        timeout: Option<Duration>,
+    ) -> anyhow::Result<ExecutionOutput> {
+        logging::with_runtime_subscriber(|| {
+            tracing::info!(target: "runtime.vm", len = script.len(), "Evaluating script");
+        });
+
+        let mut state = self.lock_state()?;
+        if state.config.execution_limit != timeout {
+            state.config.execution_limit = timeout;
+            state.rebuild_vm(&self.stdout, &self.stderr);
+        }
+
+        self.stdout.clear();
+        self.stderr.clear();
+
+        let profiling_enabled = state.profiling_flag.load(Ordering::SeqCst);
+        let start = Instant::now();
+        let result = if profiling_enabled {
+            profiling::scope!("koto_script");
+            state.koto.compile_and_run(script)
+        } else {
+            state.koto.compile_and_run(script)
+        };
+        let duration = start.elapsed();
+        let stdout = self.stdout.take();
+        let stderr = self.stderr.take();
+
+        match result {
+            Ok(value) => {
+                let output = if matches!(value, KValue::Null) {
+                    None
+                } else {
+                    Some(state.koto.value_to_string(value.clone())?)
+                };
+                logging::with_runtime_subscriber(|| {
+                    tracing::info!(target: "runtime.vm", elapsed_ms = duration.as_millis() as u64, "Script completed");
+                });
+                Ok(ExecutionOutput {
+                    return_value: output,
+                    stdout,
+                    stderr,
+                    duration,
+                })
+            }
+            Err(error) => {
+                logging::with_runtime_subscriber(|| {
+                    tracing::error!(target: "runtime.vm", %error, "Script error");
+                });
+                Err(anyhow!("{error}"))
+            }
         }
     }
 
-    pub fn evaluate_script(&self, source: &str) -> Result<String> {
-        let mut koto = self
-            .koto
+    pub fn set_execution_timeout(&self, limit: Option<Duration>) -> anyhow::Result<()> {
+        let mut state = self.lock_state()?;
+        state.config.execution_limit = limit;
+        state.rebuild_vm(&self.stdout, &self.stderr);
+        logging::with_runtime_subscriber(|| {
+            tracing::info!(
+                target: "runtime.vm",
+                timeout_ms = limit.map(|d| d.as_millis() as u64),
+                "Execution timeout updated"
+            );
+        });
+        Ok(())
+    }
+
+    pub fn set_profiling_enabled(&self, enabled: bool) {
+        self.profiling_enabled.store(enabled, Ordering::SeqCst);
+        logging::with_runtime_subscriber(|| {
+            tracing::info!(target: "runtime.vm", enabled = enabled, "Profiling updated");
+        });
+    }
+
+    pub fn register_host_function<F>(&self, name: &str, function: F) -> anyhow::Result<()>
+    where
+        F: Fn(&mut CallContext) -> KotoRuntimeResult<KValue> + KotoSend + KotoSync + 'static,
+    {
+        let mut state = self.lock_state()?;
+        let value: KValue = KNativeFunction::new(function).into();
+        state.register_host_value(name.to_string(), value);
+        logging::with_runtime_subscriber(|| {
+            tracing::info!(target: "runtime.vm", name = name, "Registered host function");
+        });
+        Ok(())
+    }
+
+    pub fn register_host_module(&self, name: &str, module: KMap) -> anyhow::Result<()> {
+        let mut state = self.lock_state()?;
+        state.register_host_value(name.to_string(), module.into());
+        logging::with_runtime_subscriber(|| {
+            tracing::info!(target: "runtime.vm", name = name, "Registered host module");
+        });
+        Ok(())
+    }
+
+    pub fn load_shared_library(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
+        let path = path.as_ref();
+        let library = unsafe { Library::new(path) }
+            .with_context(|| format!("Failed to load shared library {path:?}"))?;
+        let register: libloading::Symbol<unsafe extern "C" fn(RuntimeLibraryApi) -> bool> = unsafe {
+            library
+                .get(b"koto_register")
+                .with_context(|| format!("Library {path:?} is missing koto_register"))?
+        };
+
+        let api = RuntimeLibraryApi {
+            runtime: self as *const Runtime,
+            register_script: register_script_trampoline,
+        };
+
+        let success = unsafe { register(api) };
+        if !success {
+            return Err(anyhow!("Library {path:?} reported registration failure"));
+        }
+
+        let mut state = self.lock_state()?;
+        state.shared_libraries.push(SharedLibrary { library });
+        logging::with_runtime_subscriber(|| {
+            tracing::info!(target: "runtime.vm", path = %path.display(), "Loaded shared library");
+        });
+        Ok(())
+    }
+
+    fn lock_state(&self) -> anyhow::Result<std::sync::MutexGuard<'_, RuntimeState>> {
+        self.state
             .lock()
-            .map_err(|error| anyhow!("Failed to lock Koto runtime: {error}"))?;
-        let value = koto
-            .compile_and_run(source)
-            .map_err(|error| anyhow!("Script error: {error}"))?;
-        koto.value_to_string(value)
-            .map_err(|error| anyhow!("Failed to stringify value: {error}"))
+            .map_err(|error| anyhow!("Failed to lock runtime state: {error}"))
+    }
+}
+
+impl RuntimeState {
+    fn new(
+        config: RuntimeConfig,
+        stdout: &BufferHandle,
+        stderr: &BufferHandle,
+        profiling_flag: &Arc<AtomicBool>,
+    ) -> anyhow::Result<Self> {
+        let mut state = Self {
+            koto: Self::build_koto(&config, stdout, stderr),
+            config,
+            host_bindings: HashMap::new(),
+            shared_libraries: Vec::new(),
+            profiling_flag: profiling_flag.clone(),
+        };
+        state.register_builtin_modules()?;
+        Ok(state)
+    }
+
+    fn build_koto(config: &RuntimeConfig, stdout: &BufferHandle, stderr: &BufferHandle) -> Koto {
+        let mut settings = KotoSettings::default();
+        settings.run_tests = config.run_tests;
+        if let Some(limit) = config.execution_limit {
+            settings = settings.with_execution_limit(limit);
+        }
+        settings = settings
+            .with_stdout(stdout.file())
+            .with_stderr(stderr.file());
+        Koto::with_settings(settings)
+    }
+
+    fn rebuild_vm(&mut self, stdout: &BufferHandle, stderr: &BufferHandle) {
+        self.koto = Self::build_koto(&self.config, stdout, stderr);
+        self.apply_host_bindings();
+    }
+
+    fn register_builtin_modules(&mut self) -> anyhow::Result<()> {
+        self.register_host_value("host".to_string(), host_module(self.profiling_flag.clone()));
+        self.register_host_value("serde".to_string(), serialization_module()?);
+        Ok(())
+    }
+
+    fn register_host_value(&mut self, name: String, value: KValue) {
+        self.host_bindings.insert(name.clone(), value.clone());
+        let mut prelude = self.koto.prelude().data_mut();
+        prelude.insert(name.as_str().into(), value);
+    }
+
+    fn apply_host_bindings(&mut self) {
+        let mut prelude = self.koto.prelude().data_mut();
+        for (name, value) in &self.host_bindings {
+            prelude.insert(name.as_str().into(), value.clone());
+        }
+    }
+}
+
+impl BufferHandle {
+    fn new(id: &str) -> Self {
+        Self {
+            id: KString::from(id),
+            buffer: Arc::new(Mutex::new(String::new())),
+        }
+    }
+
+    fn file(&self) -> BufferFile {
+        BufferFile {
+            id: self.id.clone(),
+            buffer: Arc::clone(&self.buffer),
+        }
+    }
+
+    fn clear(&self) {
+        if let Ok(mut guard) = self.buffer.lock() {
+            guard.clear();
+        }
+    }
+
+    fn take(&self) -> String {
+        if let Ok(mut guard) = self.buffer.lock() {
+            let output = guard.clone();
+            guard.clear();
+            output
+        } else {
+            String::new()
+        }
+    }
+}
+
+impl KotoFile for BufferFile {
+    fn id(&self) -> KString {
+        self.id.clone()
+    }
+}
+
+impl KotoWrite for BufferFile {
+    fn write(&self, bytes: &[u8]) -> KotoRuntimeResult<()> {
+        let text = String::from_utf8_lossy(bytes);
+        if let Ok(mut guard) = self.buffer.lock() {
+            guard.push_str(&text);
+        }
+        Ok(())
+    }
+
+    fn write_line(&self, text: &str) -> KotoRuntimeResult<()> {
+        self.write(format!("{text}\n").as_bytes())?;
+        Ok(())
+    }
+
+    fn flush(&self) -> KotoRuntimeResult<()> {
+        Ok(())
+    }
+}
+
+impl KotoRead for BufferFile {}
+
+fn host_module(profiling_flag: Arc<AtomicBool>) -> KValue {
+    let module = KMap::default();
+    module.insert("version", env!("CARGO_PKG_VERSION"));
+    module.insert(
+        "echo",
+        KNativeFunction::new(|ctx: &mut CallContext| {
+            Ok(ctx.args().first().cloned().unwrap_or(KValue::Null))
+        }),
+    );
+    module.insert(
+        "profiling_enabled",
+        KNativeFunction::new(move |_ctx: &mut CallContext| {
+            Ok(profiling_flag.load(Ordering::SeqCst).into())
+        }),
+    );
+    module.insert(
+        "now",
+        KNativeFunction::new(|_ctx: &mut CallContext| {
+            let now = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+                Ok(duration) => duration,
+                Err(error) => return runtime_error!("System time error: {error}"),
+            };
+            Ok(format!("{}", now.as_secs()).into())
+        }),
+    );
+    module.into()
+}
+
+fn serialization_module() -> anyhow::Result<KValue> {
+    let module = KMap::default();
+    module.insert(
+        "to_json",
+        KNativeFunction::new(|ctx: &mut CallContext| {
+            let value = ctx.args().first().cloned().unwrap_or(KValue::Null);
+            let json: JsonValue = match koto::serde::from_koto_value(value) {
+                Ok(json) => json,
+                Err(error) => return runtime_error!("Serialization error: {error}"),
+            };
+            match serde_json::to_string_pretty(&json) {
+                Ok(text) => Ok(text.into()),
+                Err(error) => runtime_error!("Serialization error: {error}"),
+            }
+        }),
+    );
+    module.insert(
+        "from_json",
+        KNativeFunction::new(|ctx: &mut CallContext| match ctx.args() {
+            [KValue::Str(text), ..] => {
+                let parsed: JsonValue = match serde_json::from_str(text) {
+                    Ok(parsed) => parsed,
+                    Err(error) => return runtime_error!("Failed to parse JSON: {error}"),
+                };
+                match koto::serde::to_koto_value(parsed) {
+                    Ok(value) => Ok(value),
+                    Err(error) => runtime_error!("Failed to convert JSON: {error}"),
+                }
+            }
+            other => runtime_error!("Expected JSON string, found {other:?}"),
+        }),
+    );
+    Ok(module.into())
+}
+
+extern "C" fn register_script_trampoline(runtime: *const Runtime, script: *const c_char) -> bool {
+    if runtime.is_null() || script.is_null() {
+        return false;
+    }
+
+    let runtime = unsafe { &*runtime };
+    let script = unsafe { CStr::from_ptr(script) };
+    match script.to_str() {
+        Ok(source) => runtime.execute_script(source).is_ok(),
+        Err(_) => false,
+    }
+}
+
+pub mod logging {
+    use super::*;
+    use once_cell::sync::OnceCell;
+    use tracing_appender::non_blocking::WorkerGuard;
+
+    static DISPATCH: OnceCell<tracing::Dispatch> = OnceCell::new();
+    static GUARD: OnceCell<WorkerGuard> = OnceCell::new();
+
+    pub fn init() {
+        let _ = dispatcher();
+    }
+
+    pub fn with_runtime_subscriber<F, R>(f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let dispatch = dispatcher();
+        tracing::dispatcher::with_default(dispatch, f)
+    }
+
+    fn dispatcher() -> &'static tracing::Dispatch {
+        DISPATCH.get_or_init(|| {
+            let logs_dir = PathBuf::from("logs");
+            if let Err(error) = fs::create_dir_all(&logs_dir) {
+                eprintln!("Failed to create log directory {logs_dir:?}: {error}");
+            }
+            let file_appender = tracing_appender::rolling::never(&logs_dir, "runtime.log");
+            let (writer, guard) = tracing_appender::non_blocking(file_appender);
+            let dispatch = tracing_subscriber::fmt()
+                .with_ansi(false)
+                .with_max_level(Level::TRACE)
+                .with_writer(writer)
+                .finish()
+                .into();
+            let _ = GUARD.get_or_init(|| guard);
+            dispatch
+        })
     }
 }

--- a/tests/runtime_tests.rs
+++ b/tests/runtime_tests.rs
@@ -1,0 +1,94 @@
+use std::{fs, time::Duration};
+
+use koto::prelude::runtime_error;
+use koto_learning::{examples::ExampleLibrary, runtime::Runtime};
+use tempfile::tempdir;
+
+#[test]
+fn example_library_loads_and_refreshes() {
+    let temp = tempdir().expect("temp dir");
+    let base = temp.path();
+    let example_dir = base.join("demo");
+    fs::create_dir_all(&example_dir).unwrap();
+    fs::write(
+        example_dir.join("meta.json"),
+        r#"{"id":"demo","title":"Demo","description":"Test example"}"#,
+    )
+    .unwrap();
+    fs::write(example_dir.join("script.koto"), "print(\"hello\")\n42").unwrap();
+
+    let library = ExampleLibrary::new_unwatched(base.to_path_buf()).expect("library");
+    let snapshot = library.snapshot();
+    assert_eq!(snapshot.len(), 1);
+    let example = &snapshot[0];
+    assert_eq!(example.metadata.id, "demo");
+    assert_eq!(example.metadata.categories.len(), 0);
+    assert!(example.script.contains("hello"));
+
+    fs::write(example_dir.join("script.koto"), "1 + 1").unwrap();
+    library.refresh().unwrap();
+    let refreshed = library.get("demo").expect("refreshed example");
+    assert!(refreshed.script.contains("1 + 1"));
+}
+
+#[test]
+fn runtime_executes_and_captures_output() {
+    let runtime = Runtime::new().expect("runtime");
+    let output = runtime
+        .execute_script("print(\"testing\")\n1 + 2")
+        .expect("script execution");
+    assert_eq!(output.return_value.as_deref(), Some("3"));
+    assert!(output.stdout.contains("testing"));
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn runtime_reports_script_errors() {
+    let runtime = Runtime::new().expect("runtime");
+    let error = runtime.execute_script("unknown_function() ").unwrap_err();
+    assert!(error.to_string().contains("unknown_function"));
+}
+
+#[test]
+fn runtime_supports_host_functions() {
+    let runtime = Runtime::new().expect("runtime");
+    runtime
+        .register_host_function("greet", |ctx| match ctx.args() {
+            [koto::prelude::KValue::Str(name), ..] => {
+                Ok(format!("Hello {}!", name.as_str()).into())
+            }
+            _ => runtime_error!("expected name"),
+        })
+        .expect("register host function");
+
+    let output = runtime
+        .execute_script("greet(\"Runtime\")")
+        .expect("script execution");
+    assert_eq!(output.return_value.as_deref(), Some("Hello Runtime!"));
+}
+
+#[test]
+fn runtime_provides_serialization_helpers() {
+    let runtime = Runtime::new().expect("runtime");
+    let output = runtime
+        .execute_script("serde.to_json({ greeting: \"hi\" })")
+        .expect("serialization helpers");
+    let value = output.return_value.expect("json string");
+    assert!(value.contains("greeting"));
+}
+
+#[test]
+fn runtime_honors_execution_timeout_updates() {
+    let runtime = Runtime::new().expect("runtime");
+    runtime
+        .set_execution_timeout(Some(Duration::from_millis(50)))
+        .expect("set timeout");
+    runtime.execute_script("1").expect("script");
+}
+
+#[test]
+fn runtime_reports_missing_shared_library() {
+    let runtime = Runtime::new().expect("runtime");
+    let result = runtime.load_shared_library("nonexistent_library.so");
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- replace the JSON example loader with a filesystem-backed `ExampleLibrary` that watches `examples/`
- extend the runtime wrapper with buffered IO, host module registration, shared library hooks, and structured execution output
- refresh the UI assets, docs, seeded examples, and integration tests to exercise the new runtime and library

## Testing
- cargo test
 